### PR TITLE
Project V2: don't compute value for custom_url

### DIFF
--- a/selvpc/resource_selvpc_project_v2.go
+++ b/selvpc/resource_selvpc_project_v2.go
@@ -37,7 +37,6 @@ func resourceResellProjectV2() *schema.Resource {
 			"custom_url": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 				ForceNew: false,
 			},
 			"theme": {


### PR DESCRIPTION
Custom URL attribute doesn't need to be computed to allow users remove
it from project.