### PR TITLE
Docs: add website files for basic resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: go
 go:
   - "1.10.1"
+services:
+  - "docker"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - make importscheck
   - make lintcheck
   - make vet
+  - make website-test
 
 branches:
   only:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "selvpc"
+page_title: "Provider: SelVPC"
+sidebar_current: "docs-selvpc-index"
+description: |-
+  The SelVPC provider is used to interact with the Selectel VPC resources. The provider needs the Selectel API key token to authorize its requests.
+---
+
+# SelVPC provider
+
+The SelVPC provider is used to interact with the Selectel VPC resources. The provider
+needs the Selectel API key token to authorize its requests.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```hcl
+# Configure the SelVPC Provider
+provider "selvpc" {
+  token = "SELECTEL_API_TOKEN_KEY"
+}
+
+# Create a project
+resource "selvpc_resell_project_v2" "project_1" {
+  # ...
+}
+```
+
+## Configuration Reference
+
+The following arguments are supported:
+
+* `token` - (Required) The Selectel API key token. If omitted, the `SEL_TOKEN`
+  environment variable is used.
+
+* `endpoint` - (Optional) The Selectel VPC endpoint. Needed only if this provider
+  is used for tests environment. If omitted, the provider will use the official
+  Selectel VPC endpoint automatically.
+
+## Additional Logging
+
+To enable debug logging, set the `TF_LOG` environment variable to `DEBUG`:
+
+```shell
+$ env TF_LOG=DEBUG terraform apply
+```
+
+## Testing and Development
+
+In order to run the Acceptance Tests for development you need to set
+the `SEL_TOKEN` environment variable:
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN TF_ACC=1 go test -v ./selvpc/...
+```
+
+Please create an issue describing a new feature or bug prior creating a pull
+request.

--- a/website/docs/r/resell_floatingip_v2.html.markdown
+++ b/website/docs/r/resell_floatingip_v2.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "selvpc"
+page_title: "SelVPC: selvpc_resell_floatingip_v2"
+sidebar_current: "docs-selvpc-resource-resell-floatingip-v2"
+description: |-
+  Manages a V2 floatingip resource within Resell Selectel VPC.
+---
+
+# selvpc\_resell\_floatingip_v2
+
+Manages a V2 floatingip resource within Resell Selectel VPC.
+
+## Example Usage
+
+```hcl
+resource "selvpc_floatingip_v2" "floatingip_1" {
+  project_id = "887e5e35458d4ee38a6ae0543555dec5"
+  region     = "ru-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) An associated Selectel VPC project. Changing this
+  creates a new floating IP.
+
+* `region` - (Required) A region of where the floating IP resides. Changing this
+  creates a new floating IP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+`project_id` - See Argument Reference above.
+`port_id` - Contains id of the Networking service port.
+`floating_ip_address` - Contains floating IP address.
+`fixed_ip_address` - Contains internal IP address of the Networking service port.
+`region` - See Argument Reference above.
+`status` - Shows if the license is used or not.
+`servers` - Shows information about servers that use this floating IP. Contains
+`id`, `name` and `status` fields.
+
+## Import
+
+Floating IPs can be imported using the `id`, e.g.
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN terraform import selvpc_resell_floatingip_v2.floatingip_1 aa402146-d83e-4c8c-8b74-1f415d4b8253
+```

--- a/website/docs/r/resell_license_v2.html.markdown
+++ b/website/docs/r/resell_license_v2.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "selvpc"
+page_title: "SelVPC: selvpc_resell_license_v2"
+sidebar_current: "docs-selvpc-resource-resell-license-v2"
+description: |-
+  Manages a V2 license resource within Resell Selectel VPC.
+---
+
+# selvpc\_resell\_license_v2
+
+Manages a V2 license resource within Resell Selectel VPC.
+
+## Example Usage
+
+```hcl
+resource "selvpc_license_v2" "license_windows_2016_standard" {
+  project_id = "887e5e35458d4ee38a6ae0543555dec5"
+  region     = "ru-2"
+  type       = "license_windows_2012_standard"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) An associated Selectel VPC project. Changing this
+  creates a new license.
+
+* `region` - (Required) A region of where the license resides. Changing this
+  creates a new license.
+
+* `type` - (Required) A type of the license. Changing this creates a new license.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+`project_id` - See Argument Reference above.
+`region` - See Argument Reference above.
+`status` - Shows if the license is used or not.
+`servers` - Shows information about servers that use this license. Contains
+`id`, `name` and `status` fields.
+`type` - See Argument Reference above.
+
+## Import
+
+Licenses can be imported using the `id`, e.g.
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN terraform import selvpc_resell_license_v2.license_1 4123
+```

--- a/website/docs/r/resell_project_v2.html.markdown
+++ b/website/docs/r/resell_project_v2.html.markdown
@@ -1,0 +1,113 @@
+---
+layout: "selvpc"
+page_title: "SelVPC: selvpc_resell_project_v2"
+sidebar_current: "docs-selvpc-resource-resell-project-v2"
+description: |-
+  Manages a V2 project resource within Resell Selectel VPC.
+---
+
+# selvpc\_resell\_project_v2
+
+Manages a V2 project resource within Resell Selectel VPC.
+
+## Example Usage
+
+```hcl
+resource "selvpc_project_v2" "kubernetes_cluster" {
+  name       = "kubernetes_cluster"
+  custom_url = "kubernetes-cluster-123.selvpc.ru"
+  theme {
+    color = "2753E9"
+  }
+  quotas     = [
+    {
+      resource_name = "compute_cores"
+      resource_quotas = [
+        {
+          region = "ru-3"
+          zone = "ru-3a"
+          value = 12
+        }
+      ]
+    },
+    {
+      resource_name   = "compute_ram"
+      resource_quotas = [
+        {
+          region = "ru-3"
+          zone = "ru-3a"
+          value = 20480
+        }
+      ]
+    },
+    {
+      resource_name   = "volume_gigabytes_fast"
+      resource_quotas = [
+        {
+          region = "ru-3"
+          zone = "ru-3a"
+          value = 100
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the project.
+
+* `custom_url` - (Optional) The custom url for the project. Needs to be the 3d-level
+  domain for the `selvpc.ru`. Example: `terraform-project-001.selvpc.ru`.
+
+* `theme` - (Optional) An additional theme settings for this project. The structure is
+  described below.
+
+* `quotas` - (Optional) An array of desired quotas for this project. The structure is
+  described below.
+
+The `theme` block supports:
+
+* `color` - (Optional) A background color in hex format.
+
+* `logo` - (Optional) An url of the project header logo.
+
+The `quotas` block supports:
+
+* `resource_name` - (Required) A name of the billing resource to set quotas for.
+
+* `resource_quotas` - (Required) An array of desired billing quotas for this particular
+  resource. The structure is described below.
+
+The `resource_quotas` block supports:
+
+* `region` - (Optional) A Selectel VPC region for the resource quota.
+
+* `zone` - (Optional) A Selectel VPC zone for the resource quota.
+
+* `value` - (Required) A value of the resource quota.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+`name` - See Argument Reference above.
+`url` - An url of the Selectel VP project. It is set by the Selectel and can't
+be changed by the user.
+`custom_url` - See Argument Reference above.
+`enabled` - Shows if project is active or it was disabled by the Selectel.
+`theme` - See Argument Reference above.
+`quotas` - See Argument Reference above.
+`all_quotas` - Contains all quotas. They can differ from the configurable `quota`
+argument since the project will have all available resource quotas automatically applied.
+
+## Import
+
+Projects can be imported using the `id`, e.g.
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN terraform import selvpc_resell_project_v2.project_1 0a343062504b4d06a0fac375e466db25
+```

--- a/website/selvpc.erb
+++ b/website/selvpc.erb
@@ -1,0 +1,33 @@
+<% wrap_layout :inner do %>
+  <% content_for :sidebar do %>
+    <div class="docs-sidebar hidden-print affix-top" role="complementary">
+      <ul class="nav docs-sidenav">
+        <li<%= sidebar_current("docs-home") %>>
+          <a href="/docs/providers/index.html">All Providers</a>
+        </li>
+
+        <li<%= sidebar_current("docs-selvpc-index") %>>
+          <a href="/docs/providers/selvpc/index.html">SelVPC Provider</a>
+        </li>
+
+        <li<%= sidebar_current("docs-selvpc-resource-resell") %>>
+          <a href="#">Resell Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-selvpc-resource-resell-project-v2") %>>
+              <a href="/docs/providers/selvpc/r/resell_project_v2.html">selvpc_resell_project_v2</a>
+            </li>
+            <li<%= sidebar_current("docs-selvpc-resource-resell-floatingip-v2") %>>
+              <a href="/docs/providers/selvpc/r/resell_floatingip_v2.html">selvpc_resell_floatingip_v2</a>
+            </li>
+            <li<%= sidebar_current("docs-selvpc-resource-resell-license-v2") %>>
+              <a href="/docs/providers/selvpc/r/resell_license_v2.html">selvpc_resell_license_v2</a>
+            </li>
+          </ul>
+        </li>
+
+      </ul>
+    </div>
+  <% end %>
+
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
This commit adds basic website documentation files:

 - main selvpc.erb template;
 - index website file;
 - documentation about projects;
 - documentation about floating IPs;
 - documentation about licenses.

Also it adds website-test target execution to the Travis CI.