### PR TITLE
Docs: fix current resources attributes format

### DIFF
--- a/website/docs/r/resell_floatingip_v2.html.markdown
+++ b/website/docs/r/resell_floatingip_v2.html.markdown
@@ -33,14 +33,20 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-`project_id` - See Argument Reference above.
-`port_id` - Contains id of the Networking service port.
-`floating_ip_address` - Contains floating IP address.
-`fixed_ip_address` - Contains internal IP address of the Networking service port.
-`region` - See Argument Reference above.
-`status` - Shows if the license is used or not.
-`servers` - Shows information about servers that use this floating IP. Contains
-`id`, `name` and `status` fields.
+* `project_id` - See Argument Reference above.
+
+* `port_id` - Contains id of the Networking service port.
+
+* `floating_ip_address` - Contains floating IP address.
+
+* `fixed_ip_address` - Contains internal IP address of the Networking service port.
+
+* `region` - See Argument Reference above.
+
+* `status` - Shows if the license is used or not.
+
+* `servers` - Shows information about servers that use this floating IP. Contains
+  `id`, `name` and `status` fields.
 
 ## Import
 

--- a/website/docs/r/resell_license_v2.html.markdown
+++ b/website/docs/r/resell_license_v2.html.markdown
@@ -36,12 +36,16 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-`project_id` - See Argument Reference above.
-`region` - See Argument Reference above.
-`status` - Shows if the license is used or not.
-`servers` - Shows information about servers that use this license. Contains
-`id`, `name` and `status` fields.
-`type` - See Argument Reference above.
+* `project_id` - See Argument Reference above.
+
+* `region` - See Argument Reference above.
+
+* `status` - Shows if the license is used or not.
+
+* `servers` - Shows information about servers that use this license. Contains
+  `id`, `name` and `status` fields.
+
+* `type` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/resell_project_v2.html.markdown
+++ b/website/docs/r/resell_project_v2.html.markdown
@@ -94,15 +94,21 @@ The `resource_quotas` block supports:
 
 The following attributes are exported:
 
-`name` - See Argument Reference above.
-`url` - An url of the Selectel VP project. It is set by the Selectel and can't
-be changed by the user.
-`custom_url` - See Argument Reference above.
-`enabled` - Shows if project is active or it was disabled by the Selectel.
-`theme` - See Argument Reference above.
-`quotas` - See Argument Reference above.
-`all_quotas` - Contains all quotas. They can differ from the configurable `quota`
-argument since the project will have all available resource quotas automatically applied.
+* `name` - See Argument Reference above.
+
+* `url` - An url of the Selectel VP project. It is set by the Selectel and can't
+  be changed by the user.
+
+* `custom_url` - See Argument Reference above.
+
+* `enabled` - Shows if project is active or it was disabled by the Selectel.
+
+* `theme` - See Argument Reference above.
+
+* `quotas` - See Argument Reference above.
+
+* `all_quotas` - Contains all quotas. They can differ from the configurable `quota`
+  argument since the project will have all available resource quotas automatically applied.
 
 ## Import
 


### PR DESCRIPTION
Fix formatting of the "floatingip", "license", "project" attributes.

For #38 