### PR TITLE
TravisCI: change golint url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 # See: https://github.com/golang/go/issues/12933
   # - bash scripts/gogetcookie.sh
   - go get golang.org/x/tools/cmd/goimports
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/golang/dep/cmd/dep
   - go get github.com/go-critic/go-critic/...
 


### PR DESCRIPTION
Use "golang.org/x/lint/golint" for Golint.