### PR TITLE
Unset IDs on resources read errors

### DIFF
--- a/selvpc/resource_selvpc_resell_floatingip_v2.go
+++ b/selvpc/resource_selvpc_resell_floatingip_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/floatingips"
@@ -105,8 +106,13 @@ func resourceResellFloatingIPV2Read(d *schema.ResourceData, meta interface{}) er
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Getting floating ip %s", d.Id())
-	floatingIP, _, err := floatingips.Get(ctx, resellV2Client, d.Id())
+	floatingIP, response, err := floatingips.Get(ctx, resellV2Client, d.Id())
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 
@@ -131,8 +137,13 @@ func resourceResellFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) 
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Deleting floating ip %s\n", d.Id())
-	_, err := floatingips.Delete(ctx, resellV2Client, d.Id())
+	response, err := floatingips.Delete(ctx, resellV2Client, d.Id())
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/selvpc/resource_selvpc_resell_license_v2.go
+++ b/selvpc/resource_selvpc_resell_license_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -102,8 +103,13 @@ func resourceResellLicenseV2Read(d *schema.ResourceData, meta interface{}) error
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Getting license %s", d.Id())
-	license, _, err := licenses.Get(ctx, resellV2Client, d.Id())
+	license, response, err := licenses.Get(ctx, resellV2Client, d.Id())
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 
@@ -125,8 +131,13 @@ func resourceResellLicenseV2Delete(d *schema.ResourceData, meta interface{}) err
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Deleting license %s\n", d.Id())
-	_, err := licenses.Delete(ctx, resellV2Client, d.Id())
+	response, err := licenses.Delete(ctx, resellV2Client, d.Id())
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/selvpc/resource_selvpc_resell_project_v2.go
+++ b/selvpc/resource_selvpc_resell_project_v2.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -182,8 +183,13 @@ func resourceResellProjectV2Read(d *schema.ResourceData, meta interface{}) error
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Getting project %s\n", d.Id())
-	project, _, err := projects.Get(ctx, resellV2Client, d.Id())
+	project, response, err := projects.Get(ctx, resellV2Client, d.Id())
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 
@@ -271,8 +277,13 @@ func resourceResellProjectV2Delete(d *schema.ResourceData, meta interface{}) err
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Deleting project %s\n", d.Id())
-	_, err := projects.Delete(ctx, resellV2Client, d.Id())
+	response, err := projects.Delete(ctx, resellV2Client, d.Id())
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Unset ID on 404 HTTP status codes in `selvpc_resell_floatingip_v2`, `selvpc_resell_license_v2` and `selvpc_resell_project_v2` resources.

Depends on #48, #52 
For #47 