### PR TITLE
FloatingIPV2: fix project quotas in acc tests

### DIFF
--- a/selvpc/resource_selvpc_resell_floatingip_v2_test.go
+++ b/selvpc/resource_selvpc_resell_floatingip_v2_test.go
@@ -88,7 +88,8 @@ func testAccCheckResellV2FloatingIPExists(n string, floatingip *floatingips.Floa
 func testAccResellV2FloatingIPBasic(projectName string) string {
 	return fmt.Sprintf(`
 resource "selvpc_resell_project_v2" "project_tf_acc_test_1" {
-  name = "%s"
+  name        = "%s"
+  auto_quotas = true
 }
 
 resource "selvpc_resell_floatingip_v2" "floatingip_tf_acc_test_1" {


### PR DESCRIPTION
Use "auto_quotas" parameter in all floating IPs acceptance tests to set network_floating_ip quota in the created project.

For #56 