### PR TITLE
Gocritic: ignore structLitKeyOrder errors

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,8 +26,8 @@ vet:
 	fi
 
 critic:
-	@echo "gocritic check-project --enable=all -withExperimental -withOpinionated ."
-	@gocritic check-project --enable=all -withExperimental -withOpinionated .; if [ $$? -eq 1 ]; then \
+	@echo "gocritic check-project --enable=all -disable structLitKeyOrder -withExperimental -withOpinionated ."
+	@gocritic check-project --enable=all -disable structLitKeyOrder -withExperimental -withOpinionated .; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Gocritic found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \


### PR DESCRIPTION
Ignore structLitKeyOrder errors to keep this provider similar to others.

For #59 